### PR TITLE
Removes choice variable for partition

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,4 +1,4 @@
 {
-    "partition": ["core", "node", "devel", "normal", "debug"],
+    "partition": "slurm",
     "profile_name": "slurm"
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,4 +1,4 @@
 {
-    "partition": "slurm",
+    "partition": "",
     "profile_name": "slurm"
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,4 +1,4 @@
 {
-    "partition": "slurm-default",
+    "partition": "",
     "profile_name": "slurm"
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,4 +1,4 @@
 {
-    "partition": "",
+    "partition": "slurm-default",
     "profile_name": "slurm"
 }

--- a/tests/test_cookie.py
+++ b/tests/test_cookie.py
@@ -2,7 +2,7 @@
 import re
 import pytest
 
-PARTITION_RE = re.compile("^\s+arg_dict\[\"partition\"\]\s+=\s+\"(.+)\"$",
+PARTITION_RE = re.compile("^\s+arg_dict\[\"partition\"\]\s+=\s+\"(.*)\"$",
                           flags=re.MULTILINE)
 
 
@@ -21,7 +21,7 @@ def test_default_partition(cookies):
     submit_lines = "".join(submit.readlines())
     m = PARTITION_RE.search(submit_lines)
     partition = m.group(1)
-    assert partition == "core"
+    assert partition == ""
 
 
 def test_normal_partition(cookies):

--- a/{{cookiecutter.profile_name}}/slurm-submit.py
+++ b/{{cookiecutter.profile_name}}/slurm-submit.py
@@ -89,14 +89,21 @@ if "resources" in job_properties:
 if "threads" in job_properties:
     arg_dict["ntasks"] = job_properties["threads"]
 
-# Set default partition
-if arg_dict["partition"] is None:
-    arg_dict["partition"] = "{{cookiecutter.partition}}"
-
 opt_keys = ["array", "account", "begin", "cpus_per_task",
             "depedency", "workdir", "error", "job_name", "mail_type",
             "mail_user", "ntasks", "nodes", "output", "partition",
             "quiet", "time", "wrap", "constraint", "mem"]
+
+# Set default partition
+if arg_dict["partition"] is None:
+    if "{{cookiecutter.partition}}" == "slurm-default":
+        # partitions and SLURM - If not specified, the default behavior is to
+        # allow the slurm controller to select the default partition as
+        # designated by the system administrator.
+        opt_keys.remove("partition")
+    else:
+        arg_dict["partition"] = "{{cookiecutter.partition}}"
+
 opts = ""
 for k, v in arg_dict.items():
     if k not in opt_keys:

--- a/{{cookiecutter.profile_name}}/slurm-submit.py
+++ b/{{cookiecutter.profile_name}}/slurm-submit.py
@@ -96,7 +96,7 @@ opt_keys = ["array", "account", "begin", "cpus_per_task",
 
 # Set default partition
 if arg_dict["partition"] is None:
-    if "{{cookiecutter.partition}}" == "slurm-default":
+    if not "{{cookiecutter.partition}}":
         # partitions and SLURM - If not specified, the default behavior is to
         # allow the slurm controller to select the default partition as
         # designated by the system administrator.


### PR DESCRIPTION
Everyone will have different SLURM partitions into which to submit jobs. This field should not be limited to choices.