### PR TITLE
Ensure output path for Slurm logs exists

### DIFF
--- a/{{cookiecutter.profile_name}}/slurm-submit.py
+++ b/{{cookiecutter.profile_name}}/slurm-submit.py
@@ -3,6 +3,7 @@ import sys
 import re
 import argparse
 import subprocess
+from pathlib import Path
 
 from snakemake.utils import read_job_properties
 
@@ -108,6 +109,16 @@ if arg_dict["partition"] is None:
 if arg_dict["account"] is None:
     if "{{cookiecutter.account}}" != "":
         arg_dict["account"] = "{{cookiecutter.account}}"
+
+# Ensure output folder for Slurm log files exist
+# This is a bit hacky; it will try to create the folder
+# for every Slurm submission...
+if "output" in arg_dict:
+    stdout_folder = Path(arg_dict["output"]).parent
+    stdout_folder.mkdir(exist_ok=True, parents=True)
+if "error" in arg_dict:
+    stdout_folder = Path(arg_dict["error"]).parent
+    stdout_folder.mkdir(exist_ok=True, parents=True)
 
 opts = ""
 for k, v in arg_dict.items():

--- a/{{cookiecutter.profile_name}}/slurm-submit.py
+++ b/{{cookiecutter.profile_name}}/slurm-submit.py
@@ -125,7 +125,7 @@ for k, v in arg_dict.items():
     if k not in opt_keys:
         continue
     if v is not None:
-        opts += " --{} \"{}\" ".format(k, v)
+        opts += " --{} \"{}\" ".format(k.replace("_", "-", v)
 
 if arg_dict["wrap"] is not None:
     cmd = "sbatch {opts}".format(opts=opts)


### PR DESCRIPTION
This PR contains two minor improvements:

* Ensure the path component of the Slurm logfile arguments exists. It is a bit hacky, but at least you don't have to suffer Slurm jobs dying without any visible indication of why.
* Fix the construction of the `opts` arguments to `sbatch` by converting underscores back to dashes (necessary because argparse converts all dashes (`-`) in command-line arguments to underscores (`_`)).

I hope someone finds this useful.