### PR TITLE
Making days optional in _get_cluster_config

### DIFF
--- a/test-environment.yml
+++ b/test-environment.yml
@@ -3,13 +3,13 @@ channels:
   - bioconda
   - default
 dependencies:
-  - python >=3.6
+  - python ==3.6
   - pip
   - pytest
   - pytest-runner
   - docker-py >=3.0
   - cookiecutter
   - pep8
-  - pytest-cookies
+  - pytest-cookies ==0.3.0
   - pyflakes
   - snakemake ==5.3.0

--- a/tests/Snakefile
+++ b/tests/Snakefile
@@ -41,3 +41,6 @@ rule memory_with_constraint:
     shell:
         "echo {resources} > {output}"
         
+rule short_queue:
+    output: "short_queue.txt"
+    shell: "touch {output}"

--- a/tests/cluster-config.yaml
+++ b/tests/cluster-config.yaml
@@ -3,3 +3,6 @@ __default__:
 
 memory_with_constraint:
   constraint: mem800MB
+
+short_queue:
+  partition: debug

--- a/tests/test_slurm_advanced.py
+++ b/tests/test_slurm_advanced.py
@@ -3,12 +3,8 @@
 import re
 import pytest
 import logging
-from unittest.mock import patch
-from collections import namedtuple
 
 logging.getLogger("cookiecutter").setLevel(logging.DEBUG)
-
-Response = namedtuple('Response', ['stdout'])
 
 def test_adjust_runtime(cluster):
     container, data = cluster

--- a/{{cookiecutter.profile_name}}/slurm-submit-advanced.py
+++ b/{{cookiecutter.profile_name}}/slurm-submit-advanced.py
@@ -30,9 +30,11 @@ def _get_cluster_configuration(partition):
         ["sinfo -e -O \"partition,cpus,memory,time,size,maxcpuspernode\"",
          "-h -p {}".format(partition)])
     res = subprocess.run(cmd, check=True, shell=True, stdout=subprocess.PIPE)
-    m = re.search("(?P<partition>\S+)\s+(?P<cpus>\d+)\s+(?P<memory>\S+)\s+(?P<days>\d+)-(?P<hours>\d+):(?P<minutes>\d+):(?P<seconds>\d+)\s+(?P<size>\S+)\s+(?P<maxcpus>\S+)",
+    m = re.search("(?P<partition>\S+)\s+(?P<cpus>\d+)\s+(?P<memory>\S+)\s+((?P<days>\d+)-)?(?P<hours>\d+):(?P<minutes>\d+):(?P<seconds>\d+)\s+(?P<size>\S+)\s+(?P<maxcpus>\S+)",
                   res.stdout.decode())
     d = m.groupdict()
+    if not 'days' in d or not d['days']:
+        d['days'] = 0
     d["time"] = int(d['days']) * 24 * 60 + \
         int(d['hours']) * 60 + int(d['minutes']) + \
         math.ceil(int(d['seconds']) / 60)


### PR DESCRIPTION
For #17:

Fix `_get_cluster_configuration` by adding a default value and making the days capture group otherwise optional.

In order to get the unit tests running with newer versions of the slurm image I had to do some modification to the `setup_sacctmgr` function, to include a shorter queue and also remove the gres gpu lines present in the slurm config.

Note on test-environment.yml:

*   The `pytest_namespace` hook got deprecated in pytest 4.x (iirc), so I had to use version 3.10.1
*   `python>3.6` is not installed in the slurm image, therefore I pinned that version and added the `link_python` function, s.t. python can be found by `slurm_status.py` in the test environment.
*   `pytest_cookies>0.3` does not export its Cookies class anymore, so I pinned that version as well.