### PR TITLE
correctly handle status responses of the form 'CANCELLED by <uid>'

### DIFF
--- a/{{cookiecutter.profile_name}}/slurm-status.py
+++ b/{{cookiecutter.profile_name}}/slurm-status.py
@@ -42,7 +42,7 @@ if (status == "BOOT_FAIL"):
     print("failed")
 elif (status == "OUT_OF_MEMORY"):
     print("failed")
-elif (status == "CANCELLED"):
+elif (status.startswith("CANCELLED")):
     print("failed")
 elif (status == "COMPLETED"):
     print("success")


### PR DESCRIPTION
On my slurm installation, a cancelled job returns a status of the form `'CANCELLED by <uid>'`.  This was not being detected by `slurm-status.py`, and so it was returning `'running'`.  This patch addresses the issue.