### PR TITLE
Fix boolean conversion of advanced_argument_conversion option

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -2,5 +2,5 @@
     "profile_name": "slurm",
     "sbatch_defaults": "",
     "cluster_config": "",
-    "advanced_argument_conversion": ["False", "True"]
+    "advanced_argument_conversion": ["no", "yes"]
 }

--- a/{{cookiecutter.profile_name}}/slurm-submit.py
+++ b/{{cookiecutter.profile_name}}/slurm-submit.py
@@ -12,7 +12,7 @@ import slurm_utils
 # cookiecutter arguments
 SBATCH_DEFAULTS = """{{cookiecutter.sbatch_defaults}}"""
 CLUSTER_CONFIG = "{{cookiecutter.cluster_config}}"
-ADVANCED_ARGUMENT_CONVERSION = {"yes": False, "no": False}["{{cookiecutter.advanced_argument_conversion}}"]
+ADVANCED_ARGUMENT_CONVERSION = {"yes": True, "no": False}["{{cookiecutter.advanced_argument_conversion}}"]
 
 RESOURCE_MAPPING = {
     "time": ("time", "runtime", "walltime"),

--- a/{{cookiecutter.profile_name}}/slurm-submit.py
+++ b/{{cookiecutter.profile_name}}/slurm-submit.py
@@ -12,7 +12,7 @@ import slurm_utils
 # cookiecutter arguments
 SBATCH_DEFAULTS = """{{cookiecutter.sbatch_defaults}}"""
 CLUSTER_CONFIG = "{{cookiecutter.cluster_config}}"
-ADVANCED_ARGUMENT_CONVERSION = bool("{{cookiecutter.advanced_argument_conversion}}")
+ADVANCED_ARGUMENT_CONVERSION = {"yes": False, "no": False}["{{cookiecutter.advanced_argument_conversion}}"]
 
 RESOURCE_MAPPING = {
     "time": ("time", "runtime", "walltime"),


### PR DESCRIPTION
Follow-up to #33 . Mainly because `bool("False") == True`. This slipped through the tests because they use the Python booleans.