### PR TITLE
Change rulename -> rule

### DIFF
--- a/{{cookiecutter.profile_name}}/slurm-submit.py
+++ b/{{cookiecutter.profile_name}}/slurm-submit.py
@@ -40,7 +40,7 @@ sbatch_options.update(
 )
 
 # 4) cluster_config for particular rule
-sbatch_options.update(cluster_config.get(job_properties.get("rulename"), {}))
+sbatch_options.update(cluster_config.get(job_properties.get("rule"), {}))
 
 # 5) cluster_config options
 sbatch_options.update(job_properties.get("cluster", {}))


### PR DESCRIPTION
This resulted in rule-specific sbatch options not being updated from
the cluster config since there is no key called rulename in the job
properties.