### PR TITLE
Check if job has params before formatting

### DIFF
--- a/{{cookiecutter.profile_name}}/slurm_utils.py
+++ b/{{cookiecutter.profile_name}}/slurm_utils.py
@@ -65,7 +65,10 @@ def format_wildcards(string, job_properties):
             for key in job_properties:
                 setattr(self, key, job_properties[key])
     job = Job(job_properties)
-    job._format_params = Wildcards(fromdict=job_properties['params'])
+    if 'params' in job_properties:
+      job._format_params = Wildcards(fromdict=job_properties['params'])
+    else:
+      job._format_params = None
     job._format_wildcards = Wildcards(fromdict=job_properties['wildcards'])
     _variables = dict()
     _variables.update(


### PR DESCRIPTION
I was getting the following error:

```
Traceback (most recent call last):
  File "/home/twrightsman/.config/snakemake/slurm/slurm-submit.py", line 52, in <module>
    sbatch_options = slurm_utils.format_values(sbatch_options, job_properties)
  File "/home/twrightsman/.config/snakemake/slurm/slurm_utils.py", line 95, in format_values
    formatted[key] = format_wildcards(value, job_properties)
  File "/home/twrightsman/.config/snakemake/slurm/slurm_utils.py", line 68, in format_wildcards
    job._format_params = Wildcards(fromdict=job_properties['params'])
KeyError: 'params'
```