### PR TITLE
Add "partition" to resource mapping

### DIFF
--- a/{{cookiecutter.profile_name}}/slurm-submit.py
+++ b/{{cookiecutter.profile_name}}/slurm-submit.py
@@ -18,6 +18,7 @@ RESOURCE_MAPPING = {
     "mem": ("mem", "mem_mb", "ram", "memory"),
     "mem-per-cpu": ("mem-per-cpu", "mem_per_cpu", "mem_per_thread"),
     "nodes": ("nodes", "nnodes"),
+    "partition": ("partition", "queue"),
 }
 
 # parse job


### PR DESCRIPTION
I'm adding this PR instead of asking about this on an issue since it's just a single line.

We'd like to be able to specify different partitions/queues per rule, and this seems like a very straightforward way to do it. I guess that strictly speaking a queue is not a resource, so I was wondering if there's a better way to do it?

