### PR TITLE
use explicit username instead of --me

### DIFF
--- a/{{cookiecutter.profile_name}}/slurm-sidecar.py
+++ b/{{cookiecutter.profile_name}}/slurm-sidecar.py
@@ -141,7 +141,7 @@ class PollSqueueThread(threading.Thread):
         """Run the call to ``squeue``"""
         cluster = CookieCutter.get_cluster_option()
         try_num = 0
-        cmd = [SQUEUE_CMD, "--me", "--format=%i,%T", "--state=all"]
+        cmd = [SQUEUE_CMD, "--user={}".format(os.environ.get("USER")), "--format=%i,%T", "--state=all"]
         if cluster:
             cmd.append(cluster)
         while try_num < self.max_tries:

--- a/{{cookiecutter.profile_name}}/slurm-sidecar.py
+++ b/{{cookiecutter.profile_name}}/slurm-sidecar.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """Run a Snakemake v7+ sidecar process for Slurm
 
-This sidecar process will poll ``squeue --me --format='%i,%T'`` every 60
-seconds by default (use environment variable ``SNAKEMAKE_SLURM_SQUEUE_WAIT``
-for adjusting this).
+This sidecar process will poll ``squeue --user [user] --format='%i,%T'``
+every 60 seconds by default (use environment variable
+``SNAKEMAKE_SLURM_SQUEUE_WAIT`` for adjusting this).
 
 Note that you have to adjust the value to fit to your ``MinJobAge`` Slurm
 configuration.  Jobs remain at least ``MinJobAge`` seconds known to the
@@ -286,8 +286,8 @@ def main():
     poll_thread = PollSqueueThread(SQUEUE_WAIT, SQUEUE_CMD, name="poll-squeue")
     poll_thread.start()
 
-    # Initialize HTTP server that makes available the output of ``squeue --me`` in a
-    # controlled fashion.
+    # Initialize HTTP server that makes available the output of ``squeue --user [user]``
+    # in a controlled fashion.
     http_server = JobStateHttpServer(poll_thread)
     http_thread = threading.Thread(name="http-server", target=http_server.serve_forever)
     http_thread.start()


### PR DESCRIPTION
older versions of squeue (e.g., 17.02.11) do not support the "--me" option, so for backwards compatibility, using the "--user" flag followed by the username of the current user is helpful. The version of SLURM on my university's cluster is apparently several versions behind.